### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.19
 
 RUN apk --update --no-cache add git aws-cli
 


### PR DESCRIPTION
Fyi, aws-cli is not (currently) available on latest alpine 3 (3.2.x).
If it is / does become available then this change is not required.